### PR TITLE
CORE-8: updated the code to clean up the response before logging it s…

### DIFF
--- a/src/service_logging/middleware.clj
+++ b/src/service_logging/middleware.clj
@@ -33,8 +33,7 @@
 
 (defn- clean-response
   [response]
-  (dissoc response
-          :body))
+  (select-keys response [:status :headers]))
 
 (defn log-request
   [{:keys [request-method uri] :as request}]


### PR DESCRIPTION
…o that it excludes extraneous fields (e.g. from clj-http responses)

I decided which keys to keep by looking at `ring.util.http-response`. All of the functions in that namespace return only `:status`, `:headers`, and `:response` keys. Since we were excluding the `:body` key before, logging only the `:status` and `:headers` keys seems appropriate.
